### PR TITLE
Update pushconfig to remove hostname requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,29 +33,6 @@ Quickstart: Run the demo
     ping 172.16.2.101
 
 
-Topology
---------
-This demo runs on a spine-leaf topology with two single-attached hosts. The helper script `push-config.py` requires an out-of-band management network that provides access to eth0 on all of the in-band devices.
-
-         +------------+       +------------+
-         | spine01    |       | spine02    |
-         |            |       |            |
-         +------------+       +------------+
-         swp1 |    swp2 \   / swp1    | swp2
-              |           X           |
-        swp51 |   swp52 /   \ swp51   | swp52
-         +------------+       +------------+
-         | leaf01     |       | leaf02     |
-         |            |       |            |
-         +------------+       +------------+
-         swp1 |                       | swp2
-              |                       |
-         eth1 |                       | eth2
-         +------------+       +------------+
-         | server01   |       | server02   |
-         |            |       |            |
-         +------------+       +------------+
-
 
 Using the Helper Script
 -----------------------

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Quickstart: Run the demo
     git clone https://github.com/cumulusnetworks/cldemo-config-routing
     cd cldemo-config-routing
     sudo ln -s  /home/cumulus/cldemo-config-routing /var/www/cldemo-config-routing
-    python pushconfig.py bgp-unnumbered leaf01,leaf02,spine01,spine02,server01,server02
+    python pushconfig.py bgp-unnumbered
     ssh server01
     ping 172.16.2.101
 
@@ -117,7 +117,7 @@ Using a routing protocol such as BGP or OSPF means that as long as one spine is 
     sudo su - cumulus
     ssh server01
     ping 172.16.2.101
-    
+
 *In terminal 3*
 
     vagrant destroy -f spine01

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Quickstart: Run the demo
     ping 172.16.2.101
 
 
-
 Using the Helper Script
 -----------------------
 The `push-config.py` helper script deploys the configuration to the in-band network by downloading the files from the out-of-band management server. This requires a web server to be installed on the out-of-band server and passwordless login and sudo to be enabled on the in-band devices, both of which are done for you if you used [cldemo-vagrant](http://github.com/cumulusnetworks/cldemo-vagrant) to provision your topology. The demo repository needs to be linked in the management server's `/var/www/` directory:
@@ -46,7 +45,7 @@ The `push-config.py` helper script deploys the configuration to the in-band netw
 
 After setting up the repo, you can now use `push-config.py`! This script will log in to each device, download the files, and reboot the device.
 
-    python pushconfig.py <demo_name> leaf01,leaf02,spine01,spine02,server01,server02
+    python pushconfig.py <demo_name>
 
 
 Verifying Routing
@@ -69,11 +68,11 @@ Running the demo is easiest with two terminal windows open. One window will log 
 
 *In terminal 1*
 
-    python pushconfig.py ospf-unnumbered leaf01,leaf02,spine01,spine02
+    python pushconfig.py ospf-unnumbered
     # wait and watch connectivity drop and then come back
-    python pushconfig.py bgp-numbered leaf01,leaf02,spine01,spine02
+    python pushconfig.py bgp-numbered
     # again
-    python pushconfig.py bgp-unnumbered-ipv6 leaf01,leaf02,spine01,spine02,server01,server02
+    python pushconfig.py bgp-unnumbered-ipv6
     # this will reboot server01, so you'll need to log back in in terminal 2
 
 
@@ -86,7 +85,7 @@ Using a routing protocol such as BGP or OSPF means that as long as one spine is 
     vagrant ssh oob-mgmt-server
     sudo su - cumulus
     cd cldemo-config-routing
-    python pushconfig.py bgp-unnumbered leaf01,leaf02,spine01,spine02,server01,server02
+    python pushconfig.py bgp-unnumbered
 
 *In terminal 2*
 
@@ -105,7 +104,7 @@ Using a routing protocol such as BGP or OSPF means that as long as one spine is 
 
 *In terminal 1*
 
-    python pushconfig.py bgp-unnumbered spine01,spine02
+    python pushconfig.py bgp-unnumbered
     # watch Terminal 2, and pings will return
 
 

--- a/pushconfig.py
+++ b/pushconfig.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     try:
         demo = sys.argv[1]
         if len(sys.argv[2]) < 2:
-            hostnames = ["leaf01", "leaf02", "leaf03", "leaf04", "spine01", "spine02", "server01", "server02"]
+            hostnames = ["leaf01", "leaf02", "leaf03", "leaf04", "spine01", "spine02", "server01", "server02", "server03", "server04"]
         else:
             hostnames = sys.argv[2].split(',')
     except:

--- a/pushconfig.py
+++ b/pushconfig.py
@@ -48,9 +48,9 @@ def go(host, demo):
 if __name__ == "__main__":
     try:
         demo = sys.argv[1]
-        hostnames = sys.argv[2].split(',')
+        hostnames = ["leaf01", "leaf02", "leaf03", "leaf04", "spine01", "spine02", "server01", "server02"]
     except:
-        print("Usage: pushconfig.py [demo] [leaf01,leaf02,etc]")
+        print("Usage: pushconfig.py [demo]")
         sys.exit(-1)
 
     processes = []

--- a/pushconfig.py
+++ b/pushconfig.py
@@ -50,7 +50,17 @@ if __name__ == "__main__":
         demo = sys.argv[1]
         hostnames = ["leaf01", "leaf02", "leaf03", "leaf04", "spine01", "spine02", "server01", "server02"]
     except:
-        print("Usage: pushconfig.py [demo]")
+        print("Please specify the routing demo to use. One of: \n" +
+              "   bgp-numbered \n" +
+              "   bgp-numbered-ipv6 \n" +
+              "   bgp-unnumbered \n" +
+              "   bgp-unnumbered-ipv6 \n" +
+              "   ospf-numbered \n" +
+              "   ospf-numbered-ipv6 \n" +
+              "   ospf-unnumbered \n" +
+              "   ospf-unnumbered-ipv6 \n\n" +
+              "Example usage:\n" +
+              "python pushconfig.py bgp-numbered")
         sys.exit(-1)
 
     processes = []

--- a/pushconfig.py
+++ b/pushconfig.py
@@ -14,7 +14,11 @@ def go(host, demo):
     url = "http://oob-mgmt-server.lab.local/cldemo-config-routing/%s/"%demo
     expect = paramiko.SSHClient()
     expect.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    expect.connect(host, username="cumulus", password="CumulusLinux!")
+    try:
+        expect.connect(host, username="cumulus", password="CumulusLinux!")
+    except:
+        print "Paramiko Error, is " + host + " reachable?"
+        expect.close()
     commands = []
     if "server" in host:
         commands =  ['sudo wget %s/%s/interfaces'%(url, host),
@@ -48,7 +52,10 @@ def go(host, demo):
 if __name__ == "__main__":
     try:
         demo = sys.argv[1]
-        hostnames = ["leaf01", "leaf02", "leaf03", "leaf04", "spine01", "spine02", "server01", "server02"]
+        if len(sys.argv[2]) < 2:
+            hostnames = ["leaf01", "leaf02", "leaf03", "leaf04", "spine01", "spine02", "server01", "server02"]
+        else:
+            hostnames = sys.argv[2].split(',')
     except:
         print("Please specify the routing demo to use. One of: \n" +
               "   bgp-numbered \n" +


### PR DESCRIPTION
This PR assumes that pushconfig should run against all hosts. This removes the second command line argument and updates the error message to be helpful.

The readme was also updated to correct references to the script.
